### PR TITLE
Configure and deploy builder as npm package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://unpkg.com/@changesets/config@2.3.1/schema.json",
+  "changelog": ["@changesets/changelog-github", { "repo": "" }],
+  "commit": false,
+  "fixed": [],
+  "linked": [],
+  "access": "public",
+  "baseBranch": "main",
+  "updateInternalDependencies": "patch",
+  "ignore": []
+}

--- a/.changeset/first-release-builder.md
+++ b/.changeset/first-release-builder.md
@@ -1,0 +1,9 @@
+---
+"@jerry/builder": minor
+---
+
+처음 공개 배포를 위한 빌더 CLI 및 API를 추가했습니다.
+
+- CLI: `jerry-build` 추가 (watch 모드 포함)
+- Rollup 기반 빌드, 타입/스타일 옵션 지원
+- 워크스페이스 패키지 빌드를 위한 유틸 포함

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: Version and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Create Release PR or Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset version
+          publish: pnpm -r publish --access public
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/internal/builder/package.json
+++ b/internal/builder/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jerry/builder",
   "version": "0.0.0",
-  "private": true,
+  "private": false,
   "license": "MIT",
   "type": "module",
   "main": "./src/index.js",
@@ -10,6 +10,18 @@
   },
   "bin": {
     "jerry-build": "./jerry-build.js"
+  },
+  "files": [
+    "src",
+    "jerry-build.js",
+    "README.md",
+    "LICENSE"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "engines": {
+    "node": ">=18"
   },
   "dependencies": {
     "minimist": "^1.2.8",


### PR DESCRIPTION
Prepare `@jerry/builder` for its first public npm release by configuring Changesets, adding a release workflow, and updating package metadata.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc61f03f-fa0e-4bf7-8a67-e2b1583a7c28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc61f03f-fa0e-4bf7-8a67-e2b1583a7c28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

