### PR TITLE
Convert file to markdown format

### DIFF
--- a/internal/theme-builder/README.md
+++ b/internal/theme-builder/README.md
@@ -9,6 +9,7 @@ A tiny CLI and library that builds theme CSS files from a simple config. It aggr
 - **Outputs**: per-color CSS files, `all.css`, `all-colors-only.css`
 - **Workspace-aware**: aggregate dependent packages’ theme configs with `dep-sync`
 - **Programmatic API**: `init`, `sync`, `depSync`, `themeBuild`, `printHelp`
+- **Special palette**: `mono` (Radix `blackA` + `whiteA`) for guaranteed contrast utilities
 
 ---
 
@@ -22,7 +23,7 @@ yarn add -D @jerryshim/theme-builder
 npm i -D @jerryshim/theme-builder
 ```
 
-Peer requirements:
+Peer requirements
 
 - **tailwindcss >= 4.0.0** (only if you plan to integrate generated utilities with Tailwind 4)
 
@@ -30,20 +31,18 @@ Peer requirements:
 
 ### CLI
 
-The package provides a CLI:
-
 ```bash
 jerry-theme-build <command>
 ```
 
-Commands:
+Commands
 
-- `help`: Show help
-- `init [package]`: Install the component library and set up a `theme:sync` script in your `package.json`
-- `sync`: Build palettes from `jerry-theme.config.*` and write CSS files
-- `dep-sync`: Aggregate theme configs from dependencies and merge them into your main config
+- `help` – Show help
+- `init [package]` – Install the component library and set up a `theme:sync` script in your `package.json`
+- `sync` – Build palettes from `jerry-theme.config.*` and write CSS files
+- `dep-sync` – Aggregate theme configs from dependencies and merge them into your main config
 
-Options (for `dep-sync`):
+Options (for `dep-sync`)
 
 - `--format=mjs|cjs|js` Output format for the merged config (default: `mjs`)
 - `--include=@jerryshim-ui/*` Scope glob to scan in `node_modules` (default: `@jerryshim-ui/*`)
@@ -51,7 +50,7 @@ Options (for `dep-sync`):
 - `--lock` Write `jerry-theme.deps.lock.json` with sources metadata
 - `--dry` Preview only (no writes)
 
-Examples:
+Examples
 
 ```bash
 # Initialize: install component package and add a script
@@ -83,32 +82,35 @@ The theme builder looks for one of these files in your project root:
 - `jerry-theme.config.mjs`
 - `jerry-theme.config.cjs`
 
-Shape:
+Shape
 
 ```js
 // jerry-theme.config.js
 export default {
   palettes: [
-    { colorName: 'blue', colorsOnly: false, p3: true },
-    { colorName: 'green', colorsOnly: true, p3: true },
+    { colorName: 'blue',  colorsOnly: false, p3: true },
+    { colorName: 'green', colorsOnly: true,  p3: true },
+    // Special palette: blackA + whiteA utilities for guaranteed contrast
+    { colorName: 'mono',  p3: true },
   ],
   // optional (default: 'src/styles/jerry-theme')
   outDir: 'src/styles/jerry-theme',
 };
 ```
 
-Notes:
+Notes
 
 - Only **P3** palettes are currently supported; non-P3 palettes are skipped with an error log.
 - `colorsOnly: true` generates only color variables (no utility layers) for that color.
+- `mono` is a special palette built from Radix `blackA` and `whiteA` alpha scales. It ships high-contrast utilities (bg/border/divide/text) that automatically flip for dark mode.
 
-Allowed `colorName` values (Radix):
+Allowed `colorName` values (Radix)
 
 ```
 gray, mauve, slate, sage, olive, sand,
 tomato, red, crimson, pink, plum, purple, violet, indigo, blue, cyan, teal,
 green, grass, brown, orange, sky, mint, lime, yellow, amber, gold, bronze,
-iris, black, white
+iris, black, white, mono
 ```
 
 Default output directory: `src/styles/jerry-theme`
@@ -119,15 +121,72 @@ Default output directory: `src/styles/jerry-theme`
 
 For each palette, the builder writes:
 
-- `<outDir>/<color>-colors-only.css`: CSS custom properties for light/dark, solid/alpha scales
-- `<outDir>/<color>.css`: Utilities that compose variables (skipped if `colorsOnly: true`)
+- `<outDir>/<color>-colors-only.css` — CSS custom properties for light/dark, solid/alpha scales
+- `<outDir>/<color>.css` — Utilities that compose variables (skipped if `colorsOnly: true`)
+
+(For `mono`, utilities are based on `blackA`/`whiteA` only.)
 
 Aggregated entry files:
 
-- `<outDir>/all-colors-only.css`: imports all `*-colors-only.css`
-- `<outDir>/all.css`: imports all `<color>.css`
+- `<outDir>/all-colors-only.css` — imports all `*-colors-only.css`
+- `<outDir>/all.css` — imports all `<color>.css`
 
 You can import these CSS files directly in your apps or libraries.
+
+### Special: mono (blackA + whiteA)
+
+- Generates:
+  - `<outDir>/mono-colors-only.css` — exposes `blackA*` / `whiteA*` vars
+  - `<outDir>/mono.css` — high-contrast utilities that flip in dark mode
+- Included in:
+  - `all-colors-only.css` and `all.css` automatically
+
+---
+
+### Using the mono utilities
+
+`mono` picks `blackA` in light mode and `whiteA` in dark mode to keep contrast strong.
+
+Background ladder
+
+```
+bg-mono-app
+bg-mono-subtle
+bg-mono-ui
+bg-mono-ghost
+bg-mono-action
+bg-mono-solid
+```
+
+Borders & Dividers
+
+```
+border-mono-dim
+border-mono-normal
+border-mono-ui
+
+divide-mono-dim
+divide-mono-normal
+```
+
+Text/Icons (contrast against background)
+
+```
+text-on-mono         /* default strong contrast */
+text-on-mono-dim     /* slightly reduced contrast */
+placeholder-on-mono  /* placeholder-level contrast */
+text-on-mono-inverse /* inverted contrast when needed */
+```
+
+Component presets (examples)
+
+```
+mono-card     /* bg-mono-ui + text-on-mono + border-mono-dim */
+mono-surface  /* bg-mono-app + text-on-mono */
+mono-button   /* high-contrast button for both light/dark */
+```
+
+With Tailwind v4, just import the generated CSS in your project entry and use these utilities as classes.
 
 ---
 
@@ -148,10 +207,13 @@ await depSync({
   dry: false,
 });
 
-// Low-level: build CSS from an object in memory
+// Low-level: build CSS from an object in memory (mono + regular palette)
 await themeBuild({
   outputDir: 'src/styles/jerry-theme',
-  palettes: [{ colorName: 'blue', p3: true, colorsOnly: false }],
+  palettes: [
+    { colorName: 'mono', p3: true },                 // special (blackA/whiteA)
+    { colorName: 'blue', p3: true, colorsOnly: false }
+  ],
 });
 ```
 
@@ -161,10 +223,9 @@ await themeBuild({
 
 - "Unexpected export format in dist/index.js"
   - Rebuild the package (`pnpm -F @jerryshim/theme-builder build`). Ensure `dist/index.{js,cjs,d.ts}` exists.
-
 - Invalid config errors
   - Make sure `palettes` is an array and each item has a valid `colorName` from the list above.
-
+  - Note: `mono` uses alpha scales only (`blackA*`, `whiteA*`). There are no "solid" scales for black/white in Radix.
 - No files generated
   - Confirm `jerry-theme.config.*` exists at the project root, or run `dep-sync` to generate one.
 


### PR DESCRIPTION
Add documentation for the new `mono` palette, including its configuration, generated files, and utility usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-fecdf8a7-488a-4705-b7fb-d6474fbd60fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fecdf8a7-488a-4705-b7fb-d6474fbd60fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

