### PR TITLE
feat(carousel): add initial public release

### DIFF
--- a/.changeset/initial-carousel-release.md
+++ b/.changeset/initial-carousel-release.md
@@ -1,0 +1,12 @@
+---
+'@jerryshim-ui/carousel': minor
+---
+
+- **Summary**: Initial public release of `@jerryshim-ui/carousel`. Adds a React 19-compatible UI Carousel component package.
+- **Changes**
+  - New package: `@jerryshim-ui/carousel`
+  - Components: `Carousel`, `CarouselItem`, `CarouselPrev`, `CarouselNext`, `CarouselIndicators`, `CarouselIndicator`
+  - Internal deps: `@jerryshim-ui/flow-carousel`, `@jerryshim-ui/flow-dom`, `@jerryshim-ui/primitives`, `@jerryshim-ui/style-utils`
+  - Includes build, types, ESLint setup, and README
+- **Migration**: None
+- **Refs**: N/A

--- a/packages/ui/carousel/README.md
+++ b/packages/ui/carousel/README.md
@@ -1,0 +1,158 @@
+## @jerryshim-ui/carousel
+
+A headless, accessible React carousel UI built on top of `@jerryshim-ui/flow-carousel` behaviors and data attributes. Ships small, composes with Tailwind or your own CSS.
+
+### Installation
+
+```bash
+pnpm add @jerryshim-ui/carousel
+# or
+npm i @jerryshim-ui/carousel
+# or
+yarn add @jerryshim-ui/carousel
+```
+
+### Quick Start
+
+```tsx
+import '@jerryshim-ui/flow-dom/global';
+import {
+  Carousel,
+  CarouselItem,
+  CarouselPrev,
+  CarouselNext,
+  CarouselIndicators,
+  CarouselIndicator,
+} from '@jerryshim-ui/carousel';
+
+export default function Example() {
+  return (
+    <Carousel auto interval={3000} className="relative w-full">
+      <div className="relative h-56 overflow-hidden rounded-lg md:h-96">
+        <CarouselItem active>
+          <img className="block w-full h-full object-cover" src="/img1.jpg" alt="" />
+        </CarouselItem>
+        <CarouselItem>
+          <img className="block w-full h-full object-cover" src="/img2.jpg" alt="" />
+        </CarouselItem>
+        <CarouselItem>
+          <img className="block w-full h-full object-cover" src="/img3.jpg" alt="" />
+        </CarouselItem>
+      </div>
+
+      <CarouselPrev aria-label="Previous" />
+      <CarouselNext aria-label="Next" />
+
+      <CarouselIndicators>
+        <CarouselIndicator to={0} aria-label="Slide 1" />
+        <CarouselIndicator to={1} aria-label="Slide 2" />
+        <CarouselIndicator to={2} aria-label="Slide 3" />
+      </CarouselIndicators>
+    </Carousel>
+  );
+}
+```
+
+### API
+
+All components are client-side React components.
+
+```ts
+export type CarouselProps = React.HTMLAttributes<HTMLDivElement> & {
+  id?: string;
+  auto?: boolean; // enable auto slide when true
+  interval?: number; // ms, default 3000
+};
+export const Carousel: React.FC<CarouselProps>;
+
+export type CarouselItemProps = React.HTMLAttributes<HTMLDivElement> & {
+  active?: boolean; // mark initial active slide
+};
+export const CarouselItem: React.FC<CarouselItemProps>;
+
+export type CarouselPrevProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+export const CarouselPrev: React.FC<CarouselPrevProps>;
+
+export type CarouselNextProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+export const CarouselNext: React.FC<CarouselNextProps>;
+
+export type CarouselIndicatorProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  to: number; // zero-based slide index
+};
+export const CarouselIndicator: React.FC<CarouselIndicatorProps>;
+
+export type CarouselIndicatorsProps = React.HTMLAttributes<HTMLDivElement>;
+export const CarouselIndicators: React.FC<CarouselIndicatorsProps>;
+```
+
+Most components support an `asChild` prop (via `@jerryshim-ui/primitives/Slot`) to render as a custom element while preserving behavior and props: `Carousel`, `CarouselItem`, `CarouselPrev`, `CarouselNext`, `CarouselIndicator`. `CarouselIndicators` does not support `asChild`.
+
+### Options and Data Attributes
+
+- **`auto`**: When `true`, `Carousel` sets `data-carousel="slide"`; otherwise `"static"`.
+- **`interval`**: Milliseconds between auto slides; emitted as `data-carousel-interval="<ms>"`.
+- **`CarouselItem`**: Adds `data-carousel-item="active"` when `active` is true; empty string otherwise.
+- **`CarouselPrev`**: Adds `data-carousel-prev`.
+- **`CarouselNext`**: Adds `data-carousel-next`.
+- **`CarouselIndicator`**: Adds `data-carousel-slide-to="<index>"` where `<index>` is zero-based.
+
+These attributes are consumed by `@jerryshim-ui/flow-carousel` under the hood.
+
+### Usage Patterns
+
+- **Custom render element** with `asChild`:
+
+```tsx
+<Carousel asChild>
+  <section />
+</Carousel>
+```
+
+- **Controlled initial slide** via `active` on a single `CarouselItem`:
+
+```tsx
+<Carousel>
+  <CarouselItem active>First</CarouselItem>
+  <CarouselItem>Second</CarouselItem>
+  <CarouselItem>Third</CarouselItem>
+  <CarouselPrev />
+  <CarouselNext />
+  <CarouselIndicators>
+    <CarouselIndicator to={0} />
+    <CarouselIndicator to={1} />
+    <CarouselIndicator to={2} />
+  </CarouselIndicators>
+</Carousel>
+```
+
+### Accessibility
+
+- Provide `aria-label` on navigation buttons and indicators.
+- Images should include `alt` text.
+- Focus styles are not overridden; customize via className.
+
+### Styling
+
+Components ship minimal utility classes for layout/positioning. Bring your own styles (e.g., Tailwind) via `className`.
+
+- Container: defaults to `relative w-full`.
+- Items: default `hidden duration-700 ease-in-out`.
+- Controls: positioned at sides with full-height clickable area.
+- Indicators wrapper: bottom-centered row.
+
+### Integration & Lifecycle
+
+- `Carousel` imports `@jerryshim-ui/flow-dom/global` once and calls `initCarousels()` from `@jerryshim-ui/flow-carousel` on mount; it returns a disposer that runs on unmount and re-runs when the `id` changes.
+- This package is browser-only. On SSR, render markup; interactivity attaches on the client.
+
+### TypeScript
+
+Full TypeScript typings are bundled via `types` export. All components forward refs to their underlying elements.
+
+### Versioning & Breaking Changes
+
+See `CHANGELOG.md` in the repository root or package subfolder when available.
+
+### License
+
+MIT

--- a/packages/ui/carousel/eslint.config.mjs
+++ b/packages/ui/carousel/eslint.config.mjs
@@ -1,0 +1,9 @@
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import reactConfigs from '@jerryshim/eslint-config/react-package';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default [...reactConfigs({ rootDir: __dirname })];

--- a/packages/ui/carousel/package.json
+++ b/packages/ui/carousel/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@jerryshim-ui/carousel",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "dependencies": {
+    "@jerryshim-ui/flow-carousel": "workspace:*",
+    "@jerryshim-ui/primitives": "workspace:*",
+    "@jerryshim-ui/style-utils": "workspace:*"
+  },
+  "devDependencies": {
+    "@jerryshim/builder": "workspace:*",
+    "@jerryshim/eslint-config": "workspace:*",
+    "@jerryshim-ui/flow-dom": "workspace:*",
+    "@jerryshim/typescript-config": "workspace:*",
+    "@types/react": "^19.1.9",
+    "@types/react-dom": "^19.1.9",
+    "eslint": "^9.18.0",
+    "tailwindcss": "^4.1.11",
+    "typescript": "^5.9.2"
+  },
+  "peerDependencies": {
+    "react": ">=19",
+    "react-dom": ">=19",
+    "@jerryshim-ui/flow-dom": ">=0.2.0"
+  },
+  "scripts": {
+    "lint": "eslint --max-warnings 0 .",
+    "lint:fix": "eslint --fix .",
+    "build": "jerry-build .",
+    "dev": "jerry-build . --watch",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  }
+}

--- a/packages/ui/carousel/src/Carousel.test.tsx
+++ b/packages/ui/carousel/src/Carousel.test.tsx
@@ -1,0 +1,85 @@
+// Carousel.test.tsx
+import '@testing-library/jest-dom/vitest';
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@jerryshim-ui/flow-dom/global', () => ({}));
+
+vi.mock('@jerryshim-ui/flow-carousel', () => {
+  const initCarousels = vi.fn(() => () => {});
+  return { initCarousels };
+});
+
+import { initCarousels } from '@jerryshim-ui/flow-carousel';
+
+import { Carousel } from './Carousel';
+
+afterEach(() => {
+  vi.clearAllMocks();
+  cleanup();
+});
+
+// 래퍼 헬퍼: 텍스트에서 data-carousel 가진 가장 가까운 조상 잡기
+const getWrapperByChildText = (text: string) =>
+  screen.getByText(text).closest('[data-carousel]') as HTMLElement;
+
+describe('<Carousel />', () => {
+  it('renders with auto slide and interval attributes', () => {
+    render(
+      <Carousel auto interval={5000}>
+        <div>Slide A</div>
+      </Carousel>,
+    );
+
+    const wrapper = getWrapperByChildText('Slide A');
+    expect(wrapper).toHaveAttribute('data-carousel', 'slide');
+    expect(wrapper).toHaveAttribute('data-carousel-interval', '5000');
+  });
+
+  it('uses provided id and merges className', () => {
+    render(
+      <Carousel id="my-carousel" className="custom-class">
+        <div>Slide B</div>
+      </Carousel>,
+    );
+
+    const wrapper = document.getElementById('my-carousel') as HTMLElement;
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveClass('custom-class');
+    // 기본 클래스도 함께 있는지 체크하고 싶으면:
+    expect(wrapper).toHaveClass('relative', 'w-full');
+  });
+
+  it('initializes on mount, re-inits on id change, and disposes on cleanup', () => {
+    const disposer1 = vi.fn();
+    const disposer2 = vi.fn();
+
+    (initCarousels as unknown as vi.Mock)
+      .mockReturnValueOnce(disposer1)
+      .mockReturnValueOnce(disposer2);
+
+    const { rerender, unmount } = render(
+      <Carousel id="first">
+        <div>Slide C</div>
+      </Carousel>,
+    );
+
+    // mount 시 1회
+    expect(initCarousels).toHaveBeenCalledTimes(1);
+
+    // id 변경 → 이전 effect cleanup(disposer1) 호출 후 재초기화
+    rerender(
+      <Carousel id="second">
+        <div>Slide C</div>
+      </Carousel>,
+    );
+
+    expect(disposer1).toHaveBeenCalledTimes(1);
+    expect(initCarousels).toHaveBeenCalledTimes(2);
+
+    // 언마운트 → 두번째 disposer 호출
+    unmount();
+    expect(disposer2).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ui/carousel/src/Carousel.test.tsx
+++ b/packages/ui/carousel/src/Carousel.test.tsx
@@ -2,6 +2,7 @@
 import '@testing-library/jest-dom/vitest';
 
 import { cleanup, render, screen } from '@testing-library/react';
+import type { Mock } from 'vitest';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@jerryshim-ui/flow-dom/global', () => ({}));
@@ -55,7 +56,7 @@ describe('<Carousel />', () => {
     const disposer1 = vi.fn();
     const disposer2 = vi.fn();
 
-    (initCarousels as unknown as vi.Mock)
+    (initCarousels as unknown as Mock)
       .mockReturnValueOnce(disposer1)
       .mockReturnValueOnce(disposer2);
 

--- a/packages/ui/carousel/src/Carousel.tsx
+++ b/packages/ui/carousel/src/Carousel.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import '@jerryshim-ui/flow-dom/global';
+
+import { initCarousels } from '@jerryshim-ui/flow-carousel';
+import { Slot } from '@jerryshim-ui/primitives';
+import { cn } from '@jerryshim-ui/style-utils';
+import * as React from 'react';
+
+type AsChildProps = { asChild?: boolean };
+
+export type CarouselProps = React.HTMLAttributes<HTMLDivElement> &
+  AsChildProps & {
+    id?: string;
+    auto?: boolean;
+    interval?: number;
+  };
+
+export const Carousel = React.forwardRef<HTMLDivElement, CarouselProps>(
+  ({ id, className, asChild, auto, interval = 3000, children, ...props }, ref) => {
+    const Comp: any = asChild ? Slot : 'div';
+    const carouselId = React.useId();
+    const finalId = id ?? carouselId;
+
+    React.useEffect(() => {
+      const disposer = initCarousels();
+      return () => disposer();
+    }, [finalId]);
+
+    return (
+      <Comp
+        ref={ref}
+        id={finalId}
+        className={cn('relative w-full', className)}
+        data-carousel={auto ? 'slide' : 'static'}
+        data-carousel-interval={String(interval)}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+Carousel.displayName = 'Carousel';

--- a/packages/ui/carousel/src/CarouselIndicator.tsx
+++ b/packages/ui/carousel/src/CarouselIndicator.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Slot } from '@jerryshim-ui/primitives';
+import { cn } from '@jerryshim-ui/style-utils';
+import * as React from 'react';
+
+type AsChildProps = { asChild?: boolean };
+
+export type CarouselIndicatorProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  AsChildProps & {
+    to: number;
+  };
+
+export const CarouselIndicator = React.forwardRef<HTMLButtonElement, CarouselIndicatorProps>(
+  ({ className, asChild, to, children, ...props }, ref) => {
+    const Comp: any = asChild ? Slot : 'button';
+    return (
+      <Comp
+        ref={ref}
+        type="button"
+        data-carousel-slide-to={String(to)}
+        className={cn('w-3 h-3 rounded-full', className)}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+CarouselIndicator.displayName = 'CarouselIndicator';

--- a/packages/ui/carousel/src/CarouselIndicators.tsx
+++ b/packages/ui/carousel/src/CarouselIndicators.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { cn } from '@jerryshim-ui/style-utils';
+import * as React from 'react';
+
+export type CarouselIndicatorsProps = React.HTMLAttributes<HTMLDivElement>;
+
+export const CarouselIndicators = React.forwardRef<HTMLDivElement, CarouselIndicatorsProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          'absolute z-30 flex -translate-x-1/2 bottom-5 left-1/2 space-x-3 rtl:space-x-reverse',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+CarouselIndicators.displayName = 'CarouselIndicators';
+
+

--- a/packages/ui/carousel/src/CarouselItem.tsx
+++ b/packages/ui/carousel/src/CarouselItem.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Slot } from '@jerryshim-ui/primitives';
+import { cn } from '@jerryshim-ui/style-utils';
+import * as React from 'react';
+
+type AsChildProps = { asChild?: boolean };
+
+export type CarouselItemProps = React.HTMLAttributes<HTMLDivElement> &
+  AsChildProps & {
+    active?: boolean;
+  };
+
+export const CarouselItem = React.forwardRef<HTMLDivElement, CarouselItemProps>(
+  ({ className, asChild, active, children, ...props }, ref) => {
+    const Comp: any = asChild ? Slot : 'div';
+    return (
+      <Comp
+        ref={ref}
+        data-carousel-item={active ? 'active' : ''}
+        className={cn('hidden duration-700 ease-in-out', className)}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+CarouselItem.displayName = 'CarouselItem';
+
+

--- a/packages/ui/carousel/src/CarouselNext.tsx
+++ b/packages/ui/carousel/src/CarouselNext.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Slot } from '@jerryshim-ui/primitives';
+import { cn } from '@jerryshim-ui/style-utils';
+import * as React from 'react';
+
+type AsChildProps = { asChild?: boolean };
+
+export type CarouselNextProps = React.ButtonHTMLAttributes<HTMLButtonElement> & AsChildProps;
+
+export const CarouselNext = React.forwardRef<HTMLButtonElement, CarouselNextProps>(
+  ({ className, asChild, children, ...props }, ref) => {
+    const Comp: any = asChild ? Slot : 'button';
+    return (
+      <Comp
+        ref={ref}
+        type="button"
+        data-carousel-next
+        className={cn(
+          'absolute top-0 end-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+CarouselNext.displayName = 'CarouselNext';

--- a/packages/ui/carousel/src/CarouselPrev.tsx
+++ b/packages/ui/carousel/src/CarouselPrev.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Slot } from '@jerryshim-ui/primitives';
+import { cn } from '@jerryshim-ui/style-utils';
+import * as React from 'react';
+
+type AsChildProps = { asChild?: boolean };
+
+export type CarouselPrevProps = React.ButtonHTMLAttributes<HTMLButtonElement> & AsChildProps;
+
+export const CarouselPrev = React.forwardRef<HTMLButtonElement, CarouselPrevProps>(
+  ({ className, asChild, children, ...props }, ref) => {
+    const Comp: any = asChild ? Slot : 'button';
+    return (
+      <Comp
+        ref={ref}
+        type="button"
+        data-carousel-prev
+        className={cn(
+          'absolute top-0 start-0 z-30 flex items-center justify-center h-full px-4 cursor-pointer group focus:outline-none',
+          className,
+        )}
+        {...props}
+      >
+        {children}
+      </Comp>
+    );
+  },
+);
+CarouselPrev.displayName = 'CarouselPrev';

--- a/packages/ui/carousel/src/index.ts
+++ b/packages/ui/carousel/src/index.ts
@@ -1,0 +1,6 @@
+export * from './Carousel';
+export * from './CarouselIndicator';
+export * from './CarouselIndicators';
+export * from './CarouselItem';
+export * from './CarouselNext';
+export * from './CarouselPrev';

--- a/packages/ui/carousel/tsconfig.json
+++ b/packages/ui/carousel/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "@jerryshim/typescript-config/react-library",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,9 +585,6 @@ importers:
       '@jerryshim-ui/flow-carousel':
         specifier: workspace:*
         version: link:../../core/flow-carousel
-      '@jerryshim-ui/flow-dom':
-        specifier: workspace:*
-        version: link:../../core/flow-dom
       '@jerryshim-ui/primitives':
         specifier: workspace:*
         version: link:../../core/primitives
@@ -601,6 +598,9 @@ importers:
         specifier: '>=19'
         version: 19.1.1(react@19.1.1)
     devDependencies:
+      '@jerryshim-ui/flow-dom':
+        specifier: workspace:*
+        version: link:../../core/flow-dom
       '@jerryshim/builder':
         specifier: workspace:*
         version: link:../../../internal/builder


### PR DESCRIPTION
- Added new package `@jerryshim-ui/carousel`
- Provides a React 19 compatible carousel component (Carousel, CarouselItem, CarouselPrev, CarouselNext, CarouselIndicators, CarouselIndicator)
- Internal dependencies: flow-carousel, flow-dom, primitives, style-utils
- Includes build, types, ESLint, and README