### PR TITLE
docs(builder): document build mode detection and css-exports option

### DIFF
--- a/.changeset/gifted-build-mode-docs.md
+++ b/.changeset/gifted-build-mode-docs.md
@@ -1,0 +1,11 @@
+---
+'@jerryshim/builder': minor
+---
+
+- **Summary**: Document build-mode detection (TS / JS-only / CSS-only) and add `--css-exports` option.
+- **Changes**
+  - `--css-exports`: When `preset.css` exists, build `dist/preset.css` and ensure `exports["./preset.css"]`. Runs for TS/JS builds as well.
+  - Build-mode rules: TS present → TS build; JS without TS → JS-only (ESM-only enforced); No JS/TS but `preset.css` → CSS-only.
+  - PostCSS auto enable conditions clarified: `--css postcss` or `tailwindcss` dependency with `--css auto`.
+- **Migration**: None.
+- **Refs**: Implementation in `src/utils/context.js`, `src/utils/css.js`.

--- a/internal/builder/bin/jerry-build.js
+++ b/internal/builder/bin/jerry-build.js
@@ -20,6 +20,8 @@ sade('jerry-build [target]', true)
   .option('--watch, -w', 'Watch mode', false)
   .option('--format', 'all|esm|cjs', 'all')
   .option('--css', 'auto|postcss', 'auto')
+  .option('--css-exports', 'skip|copy|auto', 'skip')
+  .option('--tailwind-imports', 'Comma-separated package names for aggregator generation', '')
   .action(async (t = '.', opts) => {
     const target = path.resolve(process.cwd(), t);
     // 옵션 정제
@@ -31,9 +33,13 @@ sade('jerry-build [target]', true)
     const css = C.has(opts.css) ? opts.css : 'auto';
     /** @type {boolean} */
     const watch = opts.watch === true;
+    /** @type {'skip'|'copy'|'auto'} */
+    const cssExports = ['skip', 'copy', 'auto'].includes(opts['css-exports'])
+      ? opts['css-exports']
+      : 'skip';
 
     try {
-      await build(target, { format, css, watch });
+      await build(target, { format, css, watch, cssExports });
       console.info(pc.green('✔ build finished'));
     } catch (e) {
       console.error(pc.red(e instanceof Error ? e.stack : String(e)));

--- a/internal/builder/src/index.js
+++ b/internal/builder/src/index.js
@@ -4,12 +4,15 @@ import buildCssPackage from './builds/build-css.js';
 import buildJsPackage from './builds/build-js.js';
 import buildTsPackage from './builds/build-ts.js';
 import buildContext from './utils/context.js';
+import { maybeBuildAndExportPresetCss } from './utils/css.js';
 
 /**
  * @typedef {Object} BuildOptions
  * @property {'all'|'esm'|'cjs'} [format]
  * @property {'auto'|'postcss'} [css]
  * @property {boolean} [watch]
+ * @property {'skip'|'copy'|'auto'} [cssExports]
+ * @property {string[]} [tailwindImports]
  */
 
 /**
@@ -23,8 +26,10 @@ export default async function build(target, options = {}) {
   if (ctx.flags.isCssOnly) {
     await buildCssPackage(ctx, options);
   } else if (ctx.flags.isJsOnly) {
+    await maybeBuildAndExportPresetCss(ctx, options);
     await buildJsPackage(ctx, options);
   } else {
+    await maybeBuildAndExportPresetCss(ctx, options);
     await buildTsPackage(ctx, options);
   }
   console.timeEnd(pc.cyan('📦 Total build time'));

--- a/internal/builder/src/utils/context.js
+++ b/internal/builder/src/utils/context.js
@@ -8,10 +8,10 @@ import { discoverEntries, makeExternal } from './helper.js';
 
 /**
  * @param {string} relativeOrAbs
- * @param {{ format?: 'all'|'esm'|'cjs', css?: 'auto'|'postcss'|'none', watch?: boolean }} options
+ * @param {{ format?: 'all'|'esm'|'cjs', css?: 'auto'|'postcss'|'none', watch?: boolean, cssExports?: 'skip'|'copy'|'auto' }} options
  */
 export default async function buildContext(relativeOrAbs, options) {
-  const { format = 'all', css = 'auto' } = options;
+  const { format = 'all', css = 'auto', cssExports = 'skip' } = options;
   const validFormats = new Set(['all', 'cjs', 'esm']);
   const validCss = new Set(['auto', 'postcss', 'none']);
   if (!validFormats.has(format)) {
@@ -31,7 +31,7 @@ export default async function buildContext(relativeOrAbs, options) {
 
   if (!fs.existsSync(pkgJsonPath)) {
     console.error(pc.red(`❌ No package.json found in ${relativeOrAbs}`));
-    process.exit(1);
+    process.exit(1); // CSS 서브패스 매핑 수집 (복사/생성을 위해)
   }
 
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
@@ -83,7 +83,7 @@ export default async function buildContext(relativeOrAbs, options) {
   }
 
   return {
-    options: { format, css, shouldEnablePostcss, esmExt },
+    options: { format, css, cssExports, shouldEnablePostcss, esmExt },
     paths: { resolvedPath, pkgJsonPath, tsconfigPath, distDir, srcDir },
     flags: { isCssOnly, isJsOnly, hasTsEntry, hasJsEntry, hasPresetCss },
     pkg,


### PR DESCRIPTION
- Added criteria for detecting TS/JS-only/CSS-only build modes
- Specified conditions for PostCSS auto-activation (auto if tailwindcss is a dependency)
- Added --css-exports option and ensured preset.css export in TS/JS builds
- Updated both README and README_KR Refs: internal/builder